### PR TITLE
General improvement: Update host for the gpt.js to improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 npm-debug.log
 yarn-error.log
 .DS_Store
+.idea

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -253,7 +253,7 @@ class Bling extends Component {
         /**
          * An optional string for GPT seed file url to override.
          */
-        seedFileUrl: "//www.googletagservices.com/tag/js/gpt.js",
+        seedFileUrl: "https://securepubads.g.doubleclick.net/tag/js/gpt.js",
         /**
          * An optional flag to indicate whether an ad should only render when it's fully in the viewport area. Default is `true`.
          */


### PR DESCRIPTION
https://developers.google.com/publisher-ads-audits/reference/audits/loads-gpt-from-sgdn


> "The Google Publisher Tag library is now hosted at https://securepubads.g.doubleclick.net/tag/js/gpt.js, in addition to being hosted at the googletagservices.com domain. While not required, we strongly recommend that you update all references to GPT on your pages to use this new domain.
> This change consolidates all ad serving requests to one domain, instead of two, which means the browser only needs to connect to one domain. The library is exactly the same at both domains.
> The result is an improvement in the speed of your tags and fetching ads a bit quicker."

